### PR TITLE
feature/connection-providers

### DIFF
--- a/app/src/lib/AnchorConnectionProvider.svelte
+++ b/app/src/lib/AnchorConnectionProvider.svelte
@@ -1,16 +1,8 @@
 <script lang="ts">
-	import { setContext } from 'svelte';
 	import { Connection } from '@solana/web3.js';
 	import { workSpace } from '$utils/workSpace';
 	import { Program, Provider, web3 } from '@project-serum/anchor';
-	// import type { Idl } from '@project-serum/anchor';
 	import { walletStore } from '$utils/walletStore';
-
-	// interface IDL extends Idl {
-	// 	metadata: {
-	// 		address: string;
-	// 	};
-	// }
 
 	export let idl, network: string;
 

--- a/app/src/lib/AnchorConnectionProvider.svelte
+++ b/app/src/lib/AnchorConnectionProvider.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { setContext } from 'svelte';
+	import { Connection } from '@solana/web3.js';
+	import { workSpace } from '$utils/workSpace';
+	import { Program, Provider, web3 } from '@project-serum/anchor';
+	// import type { Idl } from '@project-serum/anchor';
+	import { walletStore } from '$utils/walletStore';
+
+	// interface IDL extends Idl {
+	// 	metadata: {
+	// 		address: string;
+	// 	};
+	// }
+
+	export let idl, network: string;
+
+	const { PublicKey } = web3;
+	const programID = new PublicKey(idl.metadata.address);
+	const baseAccount = web3.Keypair.generate();
+	const systemProgram = web3.SystemProgram;
+	const connection = new Connection(network, 'processed');
+
+	function defineProgramAndProvider(walletStore) {
+		let { sendTransaction, signTransaction, signAllTransactions, signMessage, publicKey } =
+			walletStore;
+		const providerWallet = {
+			sendTransaction,
+			signTransaction,
+			signAllTransactions,
+			signMessage,
+			publicKey
+		};
+		const provider = new Provider(connection, providerWallet, {
+			preflightCommitment: 'processed'
+		});
+		const program = new Program(idl, programID, provider);
+		workSpace.set({ baseAccount, connection, provider, program, systemProgram });
+	}
+
+	$: $walletStore && $walletStore.publicKey && defineProgramAndProvider($walletStore);
+</script>
+
+<slot />

--- a/app/src/lib/AnchorConnectionProvider.svelte
+++ b/app/src/lib/AnchorConnectionProvider.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
 	import { Connection } from '@solana/web3.js';
+	import type { Commitment, ConnectionConfig } from '@solana/web3.js';
 	import { workSpace } from '$utils/workSpace';
 	import { Program, Provider, web3 } from '@project-serum/anchor';
 	import { walletStore } from '$utils/walletStore';
 
-	export let idl, network: string;
+	export let idl,
+		network: string,
+		config: Commitment | ConnectionConfig | undefined = 'processed';
 
 	const { PublicKey } = web3;
 	const programID = new PublicKey(idl.metadata.address);
 	const baseAccount = web3.Keypair.generate();
 	const systemProgram = web3.SystemProgram;
-	const connection = new Connection(network, 'processed');
+	const connection = new Connection(network, config);
 
 	function defineProgramAndProvider(walletStore) {
 		let { sendTransaction, signTransaction, signAllTransactions, signMessage, publicKey } =

--- a/app/src/lib/ConnectionProvider.svelte
+++ b/app/src/lib/ConnectionProvider.svelte
@@ -1,33 +1,12 @@
 <script lang="ts">
 	import { Connection } from '@solana/web3.js';
+	import type { Commitment, ConnectionConfig } from '@solana/web3.js';
 	import { workSpace } from '$utils/workSpace';
-	import { Program, Provider, web3 } from '@project-serum/anchor';
-	import { walletStore } from '$utils/walletStore';
 
-	export let idl, network: string;
+	export let network: string,
+		config: Commitment | ConnectionConfig | undefined = 'processed';
 
-	const { PublicKey } = web3;
-	const programID = new PublicKey(idl.metadata.address);
-	const baseAccount = web3.Keypair.generate();
-	const systemProgram = web3.SystemProgram;
-	const connection = new Connection(network, 'processed');
+	const connection = new Connection(network, config);
 
-	function defineProgramAndProvider(walletStore) {
-		let { sendTransaction, signTransaction, signAllTransactions, signMessage, publicKey } =
-			walletStore;
-		const providerWallet = {
-			sendTransaction,
-			signTransaction,
-			signAllTransactions,
-			signMessage,
-			publicKey
-		};
-		const provider = new Provider(connection, providerWallet, {
-			preflightCommitment: 'processed'
-		});
-		const program = new Program(idl, programID, provider);
-		workSpace.set({ baseAccount, connection, provider, program, systemProgram });
-	}
-
-	$: $walletStore && $walletStore.publicKey && defineProgramAndProvider($walletStore);
+	workSpace.set({ connection });
 </script>

--- a/app/src/lib/WalletProvider.svelte
+++ b/app/src/lib/WalletProvider.svelte
@@ -9,12 +9,14 @@
 <script lang="ts">
 	import type { Wallet } from '@solana/wallet-adapter-wallets';
 	import { initialize } from '$utils/walletStore';
+	import type { WalletError } from '@solana/wallet-adapter-base';
 
 	export let localStorageKey: string,
 		wallets: Wallet[],
-		autoConnect = false;
+		autoConnect = false,
+		onError = (error: WalletError) => console.error(error);
 
-	$: wallets && initialize({ wallets, autoConnect, localStorageKey });
+	$: wallets && initialize({ wallets, autoConnect, localStorageKey, onError });
 </script>
 
 <svelte:head>

--- a/app/src/lib/WalletProvider.svelte
+++ b/app/src/lib/WalletProvider.svelte
@@ -7,7 +7,6 @@
 </script>
 
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import type { Wallet } from '@solana/wallet-adapter-wallets';
 	import { initialize } from '$utils/walletStore';
 

--- a/app/src/routes/__layout.svelte
+++ b/app/src/routes/__layout.svelte
@@ -21,8 +21,8 @@
 	});
 </script>
 
-<WalletProvider {localStorageKey} {wallets} />
-<!-- <ConnectionProvider {network} {idl} /> -->
+<WalletProvider {localStorageKey} {wallets} autoConnect />
+<!-- <ConnectionProvider {network} /> -->
 <AnchorConnectionProvider {network} {idl} />
 <div>
 	<slot />

--- a/app/src/routes/__layout.svelte
+++ b/app/src/routes/__layout.svelte
@@ -2,7 +2,8 @@
 	import { onMount } from 'svelte';
 	import { clusterApiUrl } from '@solana/web3.js';
 	import WalletProvider from '$lib/WalletProvider.svelte';
-	import ConnectionProvider from '$lib/ConnectionProvider.svelte';
+	// import ConnectionProvider from '$lib/ConnectionProvider.svelte';
+	import AnchorConnectionProvider from '$lib/AnchorConnectionProvider.svelte';
 	import idl from '../../../target/idl/solana_svelte_counter.json';
 
 	const localStorageKey = 'walletAdapter';
@@ -20,8 +21,9 @@
 	});
 </script>
 
-<WalletProvider {localStorageKey} {wallets} autoConnect />
-<ConnectionProvider {network} {idl} />
+<WalletProvider {localStorageKey} {wallets} />
+<!-- <ConnectionProvider {network} {idl} /> -->
+<AnchorConnectionProvider {network} {idl} />
 <div>
 	<slot />
 </div>

--- a/app/src/utils/workSpace.ts
+++ b/app/src/utils/workSpace.ts
@@ -1,3 +1,14 @@
 import { writable } from 'svelte/store';
+import type { Program, Provider, web3 } from '@project-serum/anchor';
+import type { Connection, Keypair } from '@solana/web3.js';
+import type { Idl } from '@project-serum/anchor';
 
-export const workSpace = writable(undefined);
+type WorkSpace = {
+	baseAccount?: Keypair;
+	connection: Connection;
+	provider?: Provider;
+	program?: Program<Idl>;
+	systemProgram?: typeof web3.SystemProgram;
+};
+
+export const workSpace = writable<WorkSpace>(undefined);


### PR DESCRIPTION
I've tried to implement `getContext()` and `setContext()` to avoid external Stores, but it has not been possible. The reason is that in the Anchor implementation, the different elements of the wallet are loaded async on the store and that doesn't work with Context API, since this one declares props to be propagated among the component tree at one time. 

Usual Svelte Stores solve this problems because they are reactive with autosubcription and that makes possible to "wait" till all the elements of the wallet are loaded to define the `workSpace` store. To make compatible both implementations and only use one store for both, only `connection` property is mandatory and the rest are optional. 

A solution to test this is to add a new route where we can make a simple transaction between wallets using pure Solana implementation (no Anchor).